### PR TITLE
Hack innecesario con Rails 3.2.22.5 y Mysql >= 5.7

### DIFF
--- a/db/migrate/20110401135022_create_sessions.rb
+++ b/db/migrate/20110401135022_create_sessions.rb
@@ -7,7 +7,6 @@ class CreateSessions < ActiveRecord::Migration
       t.timestamps
     end
 
-    execute "ALTER TABLE sessions CHANGE COLUMN data data LONGTEXT"
     add_index :sessions, :session_id
     add_index :sessions, :updated_at
   end


### PR DESCRIPTION
Este hack me impide levantar el proyecto con Postgresql. Partiendo de cero con esta rama y usando Mysql 5.7 parece ser totalmente innecesario:

![screenshot from 2017-02-22 23 31 24](https://cloud.githubusercontent.com/assets/1860816/23235994/df6dc3a6-f957-11e6-81c9-7fa21f55fe6c.png)

Aparentemente fue resuelto aquí: https://github.com/rails/rails/pull/5173/files.
