### PR TITLE
Reemplazar `serve_static_files` en favor de `public_file_server.enabled`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ COPY Gemfile Gemfile.lock ./
 RUN gem install bundler:1.17.3 && bundle _1.17.3_ install --jobs 20 --retry 5 --without development test
 
 # Set the Rails environment to production
-ENV RAILS_ENV production 
-ENV RAILS_SERVE_STATIC_FILES true
+ENV RAILS_ENV production
 
 # Copy the main application into the container
 COPY . ./

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,7 +10,7 @@ LibreTPV::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_files = true 
+  config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,7 +9,7 @@ LibreTPV::Application.configure do
   config.eager_load = true
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_files = true
+  config.public_file_server.enabled = true
   config.static_cache_control = "public, max-age=3600"
 
   # Log error messages when you accidentally call methods on nil


### PR DESCRIPTION
La configuración `serve_static_files` ha sido deprecada en favor de `public_file_server.enabled`, ref: https://github.com/rails/rails/pull/22173.

Mediante este cambio desaparece este deprecation warning en los logs al hacer arrancar la aplicación:

```
app  | DEPRECATION WARNING: `config.serve_static_files` is deprecated and will be removed in Rails 5.1.
app  | Please use `config.public_file_server.enabled = true` instead.
app  |  (called from block in <top (required)> at /railsapp/config/environments/production.rb:13)
```